### PR TITLE
Update AWS provider version constraint to allow any version >= 6.21.0

### DIFF
--- a/main/iam-oidc-provider-assume/versions.tf
+++ b/main/iam-oidc-provider-assume/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.21.0"
+      version = ">= 6.21.0"
     }
   }
 }

--- a/main/iam-oidc-provider/versions.tf
+++ b/main/iam-oidc-provider/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.21.0"
+      version = ">= 6.21.0"
     }
   }
 }

--- a/main/iam-role-assume/versions.tf
+++ b/main/iam-role-assume/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.21.0"
+      version = ">= 6.21.0"
     }
   }
 }

--- a/main/iam-role/versions.tf
+++ b/main/iam-role/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.21.0"
+      version = ">= 6.21.0"
     }
   }
 }

--- a/sub/iam-oidc-provider/versions.tf
+++ b/sub/iam-oidc-provider/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.21.0"
+      version = ">= 6.21.0"
     }
   }
 }

--- a/sub/iam-role/versions.tf
+++ b/sub/iam-role/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.21.0"
+      version = ">= 6.21.0"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the AWS provider version constraints in several Terraform modules. The version constraint for the AWS provider is changed from a specific minor version (`~> 6.21.0`) to a more flexible constraint (`>= 6.21.0`), allowing any version greater than or equal to 6.21.0. This makes it easier to use newer versions of the provider without needing to update the constraint each time.

Version constraint updates:

* Changed the AWS provider version from `~> 6.21.0` to `>= 6.21.0` in the following files:
  - `main/iam-oidc-provider-assume/versions.tf`
  - `main/iam-oidc-provider/versions.tf`
  - `main/iam-role-assume/versions.tf`
  - `main/iam-role/versions.tf`
  - `sub/iam-oidc-provider/versions.tf`
  - `sub/iam-role/versions.tf`