### PR TITLE
Fix the way shared workflows are used

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -15,11 +15,4 @@ on:
 
 jobs:
   auto-release:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: rymndhng/release-on-push-action@master
-        with:
-          bump_version_scheme: patch
-          tag_prefix: ""
+    uses: dfds/shared-workflows/.github/workflows/automation-auto-release.yml@v2.0.1

--- a/.github/workflows/block-on-hold-prs.yaml
+++ b/.github/workflows/block-on-hold-prs.yaml
@@ -2,9 +2,9 @@ name: Block on-hold PRs
 
 on:
   pull_request:
-    branches: [ master, main ]
+    branches: [main]
     types: [ opened, labeled, unlabeled, synchronize ]
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-on-hold-prs.yml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-on-hold-prs.yml@v2.0.1

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-housekeeping.yml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-housekeeping.yml@v2.0.1
     secrets: inherit # pragma: allowlist secret
     with:
       delete_head_branch: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use newer, versioned shared workflows and makes a minor correction to branch naming. These changes improve workflow reliability and maintainability by referencing specific versions instead of floating on the latest `master` branch.

**Workflow versioning and reliability:**

* Updated the `auto-release` workflow to use `dfds/shared-workflows/.github/workflows/automation-auto-release.yml@v2.0.1` instead of a custom job definition, ensuring consistent behavior and easier updates.
* Updated the `block-on-hold-prs` workflow to use `dfds/shared-workflows/.github/workflows/automation-on-hold-prs.yml@v2.0.1` instead of referencing `master`.
* Updated the `housekeeping` workflow to use `dfds/shared-workflows/.github/workflows/automation-housekeeping.yml@v2.0.1` instead of referencing `master`.

**Branch naming consistency:**

* Standardized the branch list in the `block-on-hold-prs` workflow to use `[main]` instead of `[ master, main ]`.